### PR TITLE
Inline mac tray icon and detect real user agent

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
         resolve: {
             alias: {
                 "@renderer": resolve("src/renderer"),
+                "@shared": resolve("src/shared"),
             },
         },
         plugins: [

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -63,7 +63,10 @@ function createWindow(): void {
     trayBuilder.buildMenu();
 
     mainWindow.webContents.setWindowOpenHandler((details) => {
-        shell.openExternal(details.url);
+        if (!/^https?:/i.test(details.url)) {
+            shell.openExternal(details.url);
+        }
+
         return { action: "deny" };
     });
 

--- a/src/main/ipc/browser.ts
+++ b/src/main/ipc/browser.ts
@@ -1,9 +1,11 @@
-import { ipcMain, shell } from "electron";
+import { ipcMain, session, shell } from "electron";
+import logger from "electron-log";
 import {
     getChromeInstallation,
     launchChrome,
     openChromeDownloadPage,
 } from "../browser";
+import { DEFAULT_LANGUAGE } from "../../shared/constants";
 
 function initBrowserIPC() {
     ipcMain.handle("browser:check-chrome", async () => {
@@ -14,7 +16,9 @@ function initBrowserIPC() {
         "browser:launch-chrome",
         async (
             _event,
-            payload: { url?: string; sessionId?: string } | string,
+            payload:
+                | { url?: string; sessionId?: string; language?: string }
+                | string,
         ) => {
             const targetUrl =
                 typeof payload === "string" ? payload : payload?.url ?? "";
@@ -25,8 +29,13 @@ function initBrowserIPC() {
 
             const sessionId =
                 typeof payload === "string" ? undefined : payload?.sessionId;
+            const language =
+                typeof payload === "string" ? undefined : payload?.language;
 
-            return launchChrome(targetUrl, { sessionId });
+            return launchChrome(targetUrl, {
+                sessionId,
+                language,
+            });
         },
     );
 
@@ -43,6 +52,51 @@ function initBrowserIPC() {
         await shell.openExternal(url);
         return true;
     });
+
+    ipcMain.handle(
+        "browser:configure-session",
+        async (
+            _event,
+            payload?: { sessionId?: string | null; language?: string | null },
+        ) => {
+            const sessionId = payload?.sessionId ?? null;
+            const requestedLanguage =
+                typeof payload?.language === "string"
+                    ? payload?.language.trim()
+                    : "";
+            const normalizedLanguage =
+                requestedLanguage || DEFAULT_LANGUAGE;
+
+            const partition = sessionId
+                ? `persist:chrome-${sessionId}`
+                : "persist:chrome-default";
+
+            const targetSession = session.fromPartition(partition, {
+                cache: true,
+            });
+
+            targetSession.webRequest.onBeforeSendHeaders(null);
+            targetSession.webRequest.onBeforeSendHeaders(
+                { urls: ["*://*/*"] },
+                (details, callback) => {
+                    const headers = {
+                        ...details.requestHeaders,
+                        "Accept-Language": normalizedLanguage,
+                    };
+
+                    callback({ cancel: false, requestHeaders: headers });
+                },
+            );
+
+            try {
+                targetSession.setSpellCheckerLanguages([normalizedLanguage]);
+            } catch (error) {
+                logger.warn("Failed to configure spell checker language", error);
+            }
+
+            return true;
+        },
+    );
 }
 
 export default initBrowserIPC;

--- a/src/main/ipc/browser.ts
+++ b/src/main/ipc/browser.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from "electron";
+import { ipcMain, shell } from "electron";
 import {
     getChromeInstallation,
     launchChrome,
@@ -32,6 +32,15 @@ function initBrowserIPC() {
 
     ipcMain.handle("browser:install-chrome", async () => {
         openChromeDownloadPage();
+        return true;
+    });
+
+    ipcMain.handle("browser:open-external", async (_event, url?: string) => {
+        if (!url) {
+            return false;
+        }
+
+        await shell.openExternal(url);
         return true;
     });
 }

--- a/src/main/ipc/context-menu.ts
+++ b/src/main/ipc/context-menu.ts
@@ -1,0 +1,171 @@
+import {
+    BrowserWindow,
+    Menu,
+    clipboard,
+    ipcMain,
+    shell,
+    type ContextMenuParams,
+    type MenuItemConstructorOptions,
+} from "electron";
+import { launchChrome, openChromeDownloadPage } from "../browser";
+
+type ContextMenuRequest = {
+    params?: ContextMenuParams | null;
+    sessionId?: string | null;
+    chromeInstalled?: boolean | null;
+};
+
+function buildNavigationItems(target: Electron.WebContents) {
+    const items: MenuItemConstructorOptions[] = [];
+
+    if (target.canGoBack()) {
+        items.push({
+            label: "Back",
+            click: () => target.goBack(),
+        });
+    }
+
+    if (target.canGoForward()) {
+        items.push({
+            label: "Forward",
+            click: () => target.goForward(),
+        });
+    }
+
+    items.push({
+        label: "Reload",
+        click: () => target.reload(),
+    });
+
+    return items;
+}
+
+function buildSelectionItems(params: ContextMenuParams) {
+    const items: MenuItemConstructorOptions[] = [];
+
+    items.push({
+        role: "cut",
+        enabled: params.editFlags.canCut,
+    });
+    items.push({
+        role: "copy",
+        enabled: params.editFlags.canCopy,
+    });
+    items.push({
+        role: "paste",
+        enabled: params.editFlags.canPaste,
+    });
+    items.push({
+        role: "selectAll",
+        enabled: params.editFlags.canSelectAll,
+    });
+
+    return items;
+}
+
+function buildLinkItems(
+    params: ContextMenuParams,
+    host: Electron.WebContents | null,
+    request: ContextMenuRequest,
+) {
+    if (!params.linkURL) {
+        return [] as MenuItemConstructorOptions[];
+    }
+
+    const items: MenuItemConstructorOptions[] = [];
+    const linkUrl = params.linkURL;
+
+    items.push({
+        label: "Open Link in New Tab",
+        click: () => {
+            host?.send("webview:context-open-tab", {
+                url: linkUrl,
+                sessionId: request.sessionId ?? null,
+            });
+        },
+    });
+
+    const chromeMenuLabel =
+        request.chromeInstalled === false
+            ? "Google Chrome Not Available"
+            : "Open Link in Chrome";
+
+    items.push({
+        label: chromeMenuLabel,
+        enabled: request.chromeInstalled !== false,
+        click: () => {
+            const result = launchChrome(linkUrl, {
+                sessionId: request.sessionId ?? undefined,
+            });
+
+            host?.send("webview:chrome-availability", {
+                sessionId: request.sessionId ?? null,
+                installed: result.installed && Boolean(result.path),
+            });
+        },
+    });
+
+    if (request.chromeInstalled === false) {
+        items.push({
+            label: "Install Google Chrome…",
+            click: () => {
+                openChromeDownloadPage();
+            },
+        });
+    }
+
+    items.push({
+        label: "Open Link Externally",
+        click: () => {
+            void shell.openExternal(linkUrl);
+        },
+    });
+
+    items.push({
+        label: "Copy Link Address",
+        click: () => clipboard.writeText(linkUrl),
+    });
+
+    return items;
+}
+
+export default function initContextMenuIPC(window: BrowserWindow) {
+    ipcMain.handle("webview:context-menu", (event, request: ContextMenuRequest) => {
+        if (!request?.params) {
+            return false;
+        }
+
+        const params = request.params;
+        const target = event.sender;
+        const host = target.hostWebContents || window.webContents;
+        const ownerWindow =
+            BrowserWindow.fromWebContents(host) || BrowserWindow.fromWebContents(target) || window;
+
+        const template: MenuItemConstructorOptions[] = [];
+        const navigationItems = buildNavigationItems(target);
+
+        template.push(...navigationItems);
+
+        const linkItems = buildLinkItems(params, host, request);
+        if (linkItems.length > 0) {
+            template.push({ type: "separator" }, ...linkItems);
+        }
+
+        template.push({ type: "separator" }, ...buildSelectionItems(params));
+
+        template.push({ type: "separator" });
+        template.push({
+            label: "Inspect Element",
+            click: () => target.inspectElement(params.x, params.y),
+        });
+
+        const menu = Menu.buildFromTemplate(template);
+        menu.popup({
+            window: ownerWindow,
+            x: Math.round(params.x),
+            y: Math.round(params.y),
+        });
+
+        return true;
+    });
+}

--- a/src/main/ipc/context-menu.ts
+++ b/src/main/ipc/context-menu.ts
@@ -13,6 +13,7 @@ type ContextMenuRequest = {
     params?: ContextMenuParams | null;
     sessionId?: string | null;
     chromeInstalled?: boolean | null;
+    language?: string | null;
 };
 
 function buildNavigationItems(target: Electron.WebContents) {
@@ -96,6 +97,7 @@ function buildLinkItems(
         click: () => {
             const result = launchChrome(linkUrl, {
                 sessionId: request.sessionId ?? undefined,
+                language: request.language ?? undefined,
             });
 
             host?.send("webview:chrome-availability", {

--- a/src/main/ipc/extensions.ts
+++ b/src/main/ipc/extensions.ts
@@ -1,0 +1,166 @@
+import { clipboard, ipcMain, session } from "electron";
+import type { Cookie } from "electron";
+import logger from "electron-log";
+import { INSTALLED_EXTENSIONS } from "../../shared/extensions";
+import { CHROME_EXTENSION_ID } from "../../shared/constants";
+
+interface ExtensionExecutionRequest {
+    id?: string | null;
+    partition?: string | null;
+    url?: string | null;
+}
+
+interface ExtensionExecutionResult {
+    success: boolean;
+    message: string;
+    cookies?: Cookie[];
+    copiedText?: string;
+}
+
+function resolveSession(partition?: string | null) {
+    const normalized = typeof partition === "string" ? partition.trim() : "";
+
+    if (!normalized) {
+        return session.defaultSession;
+    }
+
+    try {
+        return session.fromPartition(normalized, { cache: true });
+    } catch (error) {
+        logger.warn("Failed to resolve session partition", normalized, error);
+        return null;
+    }
+}
+
+function formatCookiesForClipboard(cookies: Cookie[]): string {
+    if (!cookies.length) {
+        return "";
+    }
+
+    const serialized = cookies.map((cookie) => ({
+        name: cookie.name,
+        value: cookie.value,
+        domain: cookie.domain,
+        hostOnly: cookie.hostOnly,
+        path: cookie.path,
+        secure: cookie.secure,
+        httpOnly: cookie.httpOnly,
+        sameSite: cookie.sameSite,
+        session: cookie.session,
+        expirationDate: cookie.expirationDate ?? null,
+    }));
+
+    return JSON.stringify(serialized, null, 2);
+}
+
+async function executeReachOwlCopyCookies(
+    request: ExtensionExecutionRequest,
+): Promise<ExtensionExecutionResult> {
+    const activeUrl = typeof request.url === "string" ? request.url : "";
+
+    if (!activeUrl) {
+        return {
+            success: false,
+            message: "No active tab URL is available for cookie extraction.",
+        };
+    }
+
+    let parsedUrl: URL;
+
+    try {
+        parsedUrl = new URL(activeUrl);
+    } catch (error) {
+        logger.warn("Failed to parse active tab URL for cookie extraction", error);
+        return {
+            success: false,
+            message: "The active tab URL is invalid.",
+        };
+    }
+
+    const targetSession = resolveSession(request.partition);
+
+    if (!targetSession) {
+        return {
+            success: false,
+            message: "Unable to access the browsing session for cookie extraction.",
+        };
+    }
+
+    let cookies: Cookie[] = [];
+
+    try {
+        cookies = await targetSession.cookies.get({ domain: parsedUrl.hostname });
+    } catch (error) {
+        logger.warn("Failed to read cookies for ReachOwl extension", error);
+        return {
+            success: false,
+            message: "Failed to read cookies for the current site.",
+        };
+    }
+
+    const clipboardPayload = formatCookiesForClipboard(cookies);
+
+    try {
+        clipboard.writeText(clipboardPayload);
+    } catch (error) {
+        logger.warn("Failed to write cookies to the clipboard", error);
+    }
+
+    const message = cookies.length
+        ? `Copied ${cookies.length} cookie${cookies.length === 1 ? "" : "s"} to the clipboard.`
+        : "No cookies were found for this site.";
+
+    return {
+        success: true,
+        message,
+        cookies,
+        copiedText: clipboardPayload,
+    };
+}
+
+function executeExtension(
+    request: ExtensionExecutionRequest,
+): Promise<ExtensionExecutionResult> {
+    if (request.id === CHROME_EXTENSION_ID) {
+        return executeReachOwlCopyCookies(request);
+    }
+
+    return Promise.resolve({
+        success: false,
+        message: "The requested extension is not available.",
+    });
+}
+
+export default function initExtensionsIPC() {
+    ipcMain.handle("extensions:list", () => INSTALLED_EXTENSIONS);
+
+    ipcMain.handle("extensions:execute", async (_event, request: ExtensionExecutionRequest) => {
+        try {
+            return await executeExtension(request ?? {});
+        } catch (error) {
+            logger.error("Unhandled error while executing extension", error);
+            return {
+                success: false,
+                message: "The extension failed to run due to an unexpected error.",
+            };
+        }
+    });
+
+    ipcMain.handle("extensions:write-clipboard", (_event, payload: { text?: string | null }) => {
+        const rawText = payload?.text;
+        const text =
+            typeof rawText === "string"
+                ? rawText
+                : rawText != null
+                    ? String(rawText)
+                    : "";
+
+        try {
+            clipboard.writeText(text);
+            return true;
+        } catch (error) {
+            logger.warn("Failed to write text to clipboard via IPC", error);
+            return false;
+        }
+    });
+}

--- a/src/main/ipc/init.ts
+++ b/src/main/ipc/init.ts
@@ -2,11 +2,13 @@ import { BrowserWindow } from "electron";
 import initWindowIPC from "./window";
 import initBrowserIPC from "./browser";
 import initContextMenuIPC from "./context-menu";
+import initExtensionsIPC from "./extensions";
 
 function ipcInit(window: BrowserWindow) {
     initWindowIPC(window);
     initBrowserIPC();
     initContextMenuIPC(window);
+    initExtensionsIPC();
 }
 
 export default ipcInit;

--- a/src/main/ipc/init.ts
+++ b/src/main/ipc/init.ts
@@ -1,10 +1,12 @@
 import { BrowserWindow } from "electron";
 import initWindowIPC from "./window";
 import initBrowserIPC from "./browser";
+import initContextMenuIPC from "./context-menu";
 
 function ipcInit(window: BrowserWindow) {
     initWindowIPC(window);
     initBrowserIPC();
+    initContextMenuIPC(window);
 }
 
 export default ipcInit;

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -1,4 +1,13 @@
-import { BrowserWindow, Menu, Tray, shell, app } from "electron";
+import {
+    BrowserWindow,
+    Menu,
+    MenuItemConstructorOptions,
+    NativeImage,
+    Tray,
+    app,
+    nativeImage,
+    shell,
+} from "electron";
 import env from "./env";
 import { getPath, logsPath } from "./util";
 
@@ -16,40 +25,90 @@ export default class TrayMenuBuilder {
     }
 
     buildMenu() {
-        this.tray = new Tray(getPath("resources/icons/icon.png"));
-
-        const contextMenu = this.buildTray();
+        const icon = this.createTrayIcon();
+        this.tray = new Tray(icon);
 
         this.tray.setToolTip(env.main.appName);
-        this.tray.setContextMenu(contextMenu);
+        this.refreshTrayMenu();
 
         this.tray.on("click", () => {
             this.mainWindow.show();
+            this.refreshTrayMenu();
         });
     }
 
+    createTrayIcon(): NativeImage {
+        if (env.platform.isMac) {
+            const svgMarkup = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><circle cx="9" cy="9" r="6" fill="#FFFFFF"/></svg>`;
+            const dataUrl = `data:image/svg+xml;base64,${Buffer.from(svgMarkup).toString(
+                "base64",
+            )}`;
+            const sizedIcon = nativeImage
+                .createFromDataURL(dataUrl)
+                .resize({ width: 18, height: 18 });
+            sizedIcon.setTemplateImage(true);
+            return sizedIcon;
+        }
+
+        return nativeImage.createFromPath(getPath("resources/icons/icon.png"));
+    }
+
+    refreshTrayMenu() {
+        if (!this.tray) {
+            return;
+        }
+
+        this.tray.setContextMenu(this.buildTray());
+    }
+
     buildTray(): Menu {
-        return Menu.buildFromTemplate([
+        return Menu.buildFromTemplate(this.buildTemplate());
+    }
+
+    buildTemplate(): MenuItemConstructorOptions[] {
+        const isVisible = this.mainWindow.isVisible();
+
+        return [
             {
                 label: "Open ReachOwl Runner",
                 click: () => {
                     this.mainWindow.show();
+                    this.refreshTrayMenu();
                 },
             },
             {
-                label: "Show logs",
+                label: isVisible ? "Hide Window" : "Show Window",
+                click: () => {
+                    if (this.mainWindow.isVisible()) {
+                        this.mainWindow.hide();
+                    } else {
+                        this.mainWindow.show();
+                    }
+
+                    this.refreshTrayMenu();
+                },
+            },
+            {
+                label: "Reload Interface",
+                click: () => {
+                    this.mainWindow.reload();
+                },
+            },
+            { type: "separator" },
+            {
+                label: "Show Logs Folder",
                 click: () => {
                     shell.openPath(logsPath);
                 },
             },
             {
-                label: "Exit",
+                label: "Close Daemon",
                 click: async () => {
                     app.exit();
                     app.quit();
                 },
             },
-        ]);
+        ];
     }
 
     destroyMenu() {

--- a/src/renderer/components/view/controls/extensions.vue
+++ b/src/renderer/components/view/controls/extensions.vue
@@ -1,0 +1,88 @@
+<template>
+    <div class="extensions-bar">
+        <button
+            v-for="extension in extensions"
+            :key="extension.id"
+            class="extensions-button"
+            :disabled="executing"
+            :title="extension.description || extension.name"
+            type="button"
+            @click="$emit('activate', extension)"
+        >
+            <span class="extensions-button-badge">{{ extension.badge || extension.name.charAt(0) }}</span>
+            <span class="extensions-button-label">{{ extension.name }}</span>
+        </button>
+    </div>
+</template>
+
+<script lang="ts">
+import type { PropType } from "vue";
+import type { InstalledExtension } from "@shared/extensions";
+
+export default {
+    name: "ExtensionsBar",
+    props: {
+        extensions: {
+            type: Array as PropType<InstalledExtension[]>,
+            default: () => [],
+        },
+        executing: {
+            type: Boolean,
+            default: false,
+        },
+    },
+    emits: ["activate"],
+};
+</script>
+
+<style scoped lang="scss">
+.extensions-bar {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    background: #f3ba6c;
+    border-bottom: 1px solid #f0a94a;
+}
+
+.extensions-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border: 0;
+    border-radius: 16px;
+    padding: 6px 12px;
+    background: rgba(63, 42, 8, 0.1);
+    color: #3f2a08;
+    font-size: 12px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, opacity 0.2s ease;
+
+    &:hover:not(:disabled) {
+        background: rgba(63, 42, 8, 0.18);
+    }
+
+    &:disabled {
+        cursor: wait;
+        opacity: 0.7;
+    }
+}
+
+.extensions-button-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    border-radius: 10px;
+    background: #3f2a08;
+    color: #ffd7a3;
+    font-weight: 600;
+    font-size: 10px;
+    text-transform: uppercase;
+}
+
+.extensions-button-label {
+    white-space: nowrap;
+}
+</style>

--- a/src/renderer/components/view/controls/url.vue
+++ b/src/renderer/components/view/controls/url.vue
@@ -50,6 +50,10 @@ export default {
                 return "";
             }
 
+            if (this.looksLikeSearchQuery(trimmed)) {
+                return `https://www.google.com/search?q=${encodeURIComponent(trimmed)}`;
+            }
+
             const uri = URI(trimmed);
             const protocol = uri.protocol();
 
@@ -58,6 +62,41 @@ export default {
             }
 
             return uri.toString();
+        },
+
+        looksLikeSearchQuery(value: string) {
+            if (!value) {
+                return true;
+            }
+
+            if (/\s/.test(value)) {
+                return true;
+            }
+
+            const lowerValue = value.toLowerCase();
+
+            const hasProtocol = /^[a-z][a-z0-9+.-]*:\/\//.test(lowerValue);
+            if (hasProtocol) {
+                return false;
+            }
+
+            if (lowerValue.startsWith("localhost")) {
+                return false;
+            }
+
+            if (/^(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?(\/.*)?$/.test(lowerValue)) {
+                return false;
+            }
+
+            if (/^[\w-]+(\.[\w-]+)+(?:[:\/].*)?$/.test(lowerValue)) {
+                return false;
+            }
+
+            if (/^www\./.test(lowerValue)) {
+                return false;
+            }
+
+            return true;
         },
 
         onFocus(event) {

--- a/src/renderer/components/view/pages/settings.vue
+++ b/src/renderer/components/view/pages/settings.vue
@@ -68,7 +68,7 @@
                             readonly
                         />
                         <p class="field-hint">
-                            Chrome's default user agent is enforced for all
+                            Your current user agent is enforced for all
                             sessions.
                         </p>
                     </div>
@@ -129,7 +129,7 @@ import { mapGetters, mapMutations } from "vuex";
 import {
     defaultBrowserPreference,
     defaultHomePage,
-    defaultUserAgent as chromeLikeUserAgent,
+    defaultUserAgent,
 } from "@renderer/data/main";
 
 function getIpcRenderer() {
@@ -149,7 +149,7 @@ export default {
     computed: {
         ...mapGetters("sessions", ["currentSession", "currentSessionIndex"]),
         enforcedUserAgent(): string {
-            return chromeLikeUserAgent;
+            return defaultUserAgent;
         },
     },
 
@@ -184,7 +184,7 @@ export default {
                     });
                 }
 
-                const enforcedUserAgent = chromeLikeUserAgent;
+                const enforcedUserAgent = defaultUserAgent;
 
                 if (session.settings.userAgent !== enforcedUserAgent) {
                     this.updateSessionSetting({

--- a/src/renderer/components/view/pages/webview.vue
+++ b/src/renderer/components/view/pages/webview.vue
@@ -224,8 +224,26 @@ export default {
         },
 
         navigate(url: string) {
-            if (url !== this.view?.getURL()) {
-                this.view?.loadURL(url);
+            if (url === this.view?.getURL()) {
+                return;
+            }
+
+            const promise = this.view?.loadURL(url);
+
+            if (promise && typeof promise.catch === "function") {
+                promise.catch((error: Error & { code?: number | string; errno?: number | string }) => {
+                    const errorCode = error?.errno ?? error?.code;
+
+                    if (
+                        errorCode === -3 ||
+                        errorCode === "ERR_ABORTED" ||
+                        error?.message?.includes?.("-3")
+                    ) {
+                        return;
+                    }
+
+                    console.warn("Failed to navigate webview", error);
+                });
             }
         },
 

--- a/src/renderer/components/view/pages/webview.vue
+++ b/src/renderer/components/view/pages/webview.vue
@@ -25,6 +25,59 @@
             <url :value="currentTab.url" @navigate="navigate($event)" />
         </div>
 
+        <extensions-bar
+            v-if="availableExtensions.length"
+            :extensions="availableExtensions"
+            :executing="extensionExecuting"
+            @activate="handleExtensionActivation"
+        />
+
+        <div
+            v-if="extensionFeedback"
+            class="extension-feedback"
+            :class="{ 'is-error': extensionFeedbackType === 'error' }"
+        >
+            {{ extensionFeedback }}
+        </div>
+
+        <div v-if="extensionPanel" class="extension-panel">
+            <div class="extension-panel__header">
+                <div class="extension-panel__summary">
+                    <h3>{{ extensionPanel.extension.name }}</h3>
+                    <p>{{ extensionPanel.extension.description }}</p>
+                </div>
+                <button
+                    type="button"
+                    class="extension-panel__close"
+                    @click="closeExtensionPanel"
+                    aria-label="Close extension panel"
+                >
+                    <i class="fa fa-times" aria-hidden="true" />
+                </button>
+            </div>
+            <div class="extension-panel__body">
+                <p
+                    v-if="!extensionPanel.cookies.length"
+                    class="extension-panel__empty"
+                >
+                    No cookies were found for this site.
+                </p>
+                <pre v-else class="extension-panel__code">{{
+                    extensionPanel.copiedText
+                }}</pre>
+            </div>
+            <div class="extension-panel__actions">
+                <button
+                    type="button"
+                    class="extension-panel__action"
+                    @click="copyCookiesAgain"
+                >
+                    <i class="fa fa-clipboard" aria-hidden="true" />
+                    Copy cookies
+                </button>
+            </div>
+        </div>
+
         <div
             v-if="
                 isChromeBrowser &&
@@ -63,15 +116,23 @@
 
 <script lang="ts">
 import Url from "./../controls/url.vue";
-import type { ContextMenuParams, WebviewTag } from "electron";
+import ExtensionsBar from "../controls/extensions.vue";
+import type { Cookie, ContextMenuParams, WebviewTag } from "electron";
 import get from "lodash/get";
 import { mapGetters, mapMutations } from "vuex";
 import { defaultLanguage } from "@renderer/data/main";
 import { configureSessionLanguage } from "@renderer/ipc/browser";
+import type { InstalledExtension } from "@shared/extensions";
 
 function getIpcRenderer() {
     return window.electron?.ipcRenderer;
 }
+
+type ExtensionPanelState = {
+    extension: InstalledExtension;
+    cookies: Cookie[];
+    copiedText: string;
+};
 
 const events = {
     "did-finish-load": "didFinishLoad",
@@ -86,6 +147,7 @@ const events = {
 export default {
     components: {
         Url,
+        ExtensionsBar,
     },
     data() {
         return {
@@ -93,6 +155,12 @@ export default {
             loading: false,
             chromeInstalled: null as null | boolean,
             checkingChrome: false,
+            extensions: [] as InstalledExtension[],
+            extensionPanel: null as ExtensionPanelState | null,
+            extensionExecuting: false,
+            extensionFeedback: null as string | null,
+            extensionFeedbackType: "success" as "success" | "error",
+            extensionFeedbackTimer: null as number | null,
         };
     },
 
@@ -119,6 +187,13 @@ export default {
             const sessionId = this.currentTab?.session ?? "unknown";
             return `${sessionId}-chrome`;
         },
+        availableExtensions(): InstalledExtension[] {
+            if (!this.isChromeBrowser) {
+                return [];
+            }
+
+            return this.extensions;
+        },
     },
 
     watch: {
@@ -127,7 +202,12 @@ export default {
             handler(isChrome: boolean) {
                 if (isChrome) {
                     this.switchToChromeMode();
+                    this.loadExtensions();
+                    return;
                 }
+
+                this.extensionPanel = null;
+                this.extensions = [];
             },
         },
         "currentSession.settings.language": {
@@ -137,9 +217,15 @@ export default {
                 void this.configureLanguage(normalized);
             },
         },
+        "currentTab.url"(newUrl: string | undefined, oldUrl: string | undefined) {
+            if (newUrl !== oldUrl) {
+                this.extensionPanel = null;
+            }
+        },
     },
 
     mounted() {
+        this.loadExtensions();
         const ipcRenderer = getIpcRenderer();
         ipcRenderer?.on("webview:context-open-tab", this.handleContextMenuCommand);
         ipcRenderer?.on(
@@ -158,6 +244,7 @@ export default {
             "webview:chrome-availability",
             this.handleChromeAvailabilityEvent,
         );
+        this.clearExtensionFeedbackTimer();
         this.removeEventListeners();
     },
 
@@ -177,6 +264,44 @@ export default {
         async configureLanguage(language: string) {
             const sessionId = this.currentSession?.id ?? null;
             await configureSessionLanguage(sessionId, language);
+        },
+
+        async loadExtensions() {
+            try {
+                const ipcRenderer = getIpcRenderer();
+
+                if (!ipcRenderer) {
+                    return;
+                }
+
+                const result = await ipcRenderer.invoke("extensions:list");
+
+                if (Array.isArray(result)) {
+                    this.extensions = result as InstalledExtension[];
+                } else {
+                    this.extensions = [];
+                }
+            } catch (error) {
+                console.error("Failed to load extensions", error);
+            }
+        },
+
+        clearExtensionFeedbackTimer() {
+            if (this.extensionFeedbackTimer !== null) {
+                window.clearTimeout(this.extensionFeedbackTimer);
+                this.extensionFeedbackTimer = null;
+            }
+        },
+
+        showExtensionFeedback(message: string, isError = false) {
+            this.clearExtensionFeedbackTimer();
+            this.extensionFeedback = message;
+            this.extensionFeedbackType = isError ? "error" : "success";
+
+            this.extensionFeedbackTimer = window.setTimeout(() => {
+                this.extensionFeedback = null;
+                this.extensionFeedbackTimer = null;
+            }, 5000);
         },
 
         async checkChromeAvailability() {
@@ -221,6 +346,156 @@ export default {
             );
             void this.configureLanguage(language);
             this.checkChromeAvailability();
+        },
+
+        formatCookiesForClipboard(cookies: Cookie[]): string {
+            if (!cookies.length) {
+                return "";
+            }
+
+            const serialized = cookies.map((cookie) => ({
+                name: cookie.name,
+                value: cookie.value,
+                domain: cookie.domain,
+                hostOnly: cookie.hostOnly,
+                path: cookie.path,
+                secure: cookie.secure,
+                httpOnly: cookie.httpOnly,
+                sameSite: cookie.sameSite,
+                session: cookie.session,
+                expirationDate: cookie.expirationDate ?? null,
+            }));
+
+            return JSON.stringify(serialized, null, 2);
+        },
+
+        async handleExtensionActivation(extension: InstalledExtension) {
+            if (!extension || this.extensionExecuting) {
+                return;
+            }
+
+            const ipcRenderer = getIpcRenderer();
+
+            if (!ipcRenderer) {
+                this.showExtensionFeedback(
+                    "Extension bridge is unavailable.",
+                    true,
+                );
+                return;
+            }
+
+            this.extensionExecuting = true;
+
+            try {
+                const result = await ipcRenderer.invoke(
+                    "extensions:execute",
+                    {
+                        id: extension.id,
+                        partition: this.webviewPartition,
+                        url: this.currentTab?.url ?? null,
+                    },
+                );
+
+                const message =
+                    typeof result?.message === "string"
+                        ? result.message
+                        : `${extension.name} finished running.`;
+
+                if (result?.success) {
+                    const cookies = Array.isArray(result.cookies)
+                        ? (result.cookies as Cookie[])
+                        : [];
+                    const copiedText =
+                        typeof result.copiedText === "string"
+                            ? result.copiedText
+                            : this.formatCookiesForClipboard(cookies);
+
+                    this.extensionPanel = {
+                        extension,
+                        cookies,
+                        copiedText,
+                    };
+                } else {
+                    this.extensionPanel = null;
+                }
+
+                this.showExtensionFeedback(message, !result?.success);
+            } catch (error) {
+                console.error("Failed to execute extension", error);
+                this.extensionPanel = null;
+                this.showExtensionFeedback(
+                    `Failed to run ${extension.name}.`,
+                    true,
+                );
+            } finally {
+                this.extensionExecuting = false;
+            }
+        },
+
+        closeExtensionPanel() {
+            this.extensionPanel = null;
+        },
+
+        async copyCookiesAgain() {
+            if (!this.extensionPanel) {
+                return;
+            }
+
+            const text =
+                this.extensionPanel.copiedText ||
+                this.formatCookiesForClipboard(this.extensionPanel.cookies);
+
+            if (!text) {
+                this.showExtensionFeedback(
+                    "There are no cookies to copy.",
+                    true,
+                );
+                return;
+            }
+
+            try {
+                if (navigator?.clipboard?.writeText) {
+                    await navigator.clipboard.writeText(text);
+                } else {
+                    const ipcRenderer = getIpcRenderer();
+                    if (ipcRenderer) {
+                        await ipcRenderer.invoke("extensions:write-clipboard", {
+                            text,
+                        });
+                    }
+                }
+
+                this.showExtensionFeedback("Cookies copied to the clipboard.");
+            } catch (error) {
+                console.error("Failed to copy cookies from extension", error);
+
+                try {
+                    const ipcRenderer = getIpcRenderer();
+                    if (ipcRenderer) {
+                        const success = await ipcRenderer.invoke(
+                            "extensions:write-clipboard",
+                            { text },
+                        );
+
+                        if (success) {
+                            this.showExtensionFeedback(
+                                "Cookies copied to the clipboard.",
+                            );
+                            return;
+                        }
+                    }
+                } catch (ipcError) {
+                    console.error(
+                        "Failed to copy cookies via IPC fallback",
+                        ipcError,
+                    );
+                }
+
+                this.showExtensionFeedback(
+                    "Unable to copy cookies to the clipboard.",
+                    true,
+                );
+            }
         },
 
         navigate(url: string) {
@@ -483,6 +758,113 @@ export default {
             }
         }
     }
+}
+
+.extension-feedback {
+    padding: 6px 10px;
+    background: #ffe2b5;
+    border-bottom: 1px solid #f0a94a;
+    color: #3f2a08;
+    font-size: 12px;
+}
+
+.extension-feedback.is-error {
+    background: #f6c1b5;
+    border-color: #e69385;
+    color: #5b1f12;
+}
+
+.extension-panel {
+    margin: 10px;
+    padding: 12px;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.78);
+    border: 1px solid #f0a94a;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.extension-panel__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.extension-panel__summary h3 {
+    margin: 0;
+    font-size: 14px;
+    color: #3f2a08;
+}
+
+.extension-panel__summary p {
+    margin: 4px 0 0;
+    font-size: 12px;
+    color: #514325;
+}
+
+.extension-panel__close {
+    border: 0;
+    background: transparent;
+    color: #3f2a08;
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 50%;
+    transition: background-color 0.2s ease;
+}
+
+.extension-panel__close:hover {
+    background-color: rgba(63, 42, 8, 0.12);
+}
+
+.extension-panel__body {
+    max-height: 240px;
+    overflow: auto;
+    background: rgba(255, 249, 238, 0.9);
+    border: 1px dashed rgba(63, 42, 8, 0.3);
+    border-radius: 8px;
+    padding: 10px;
+}
+
+.extension-panel__code {
+    margin: 0;
+    font-size: 12px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: #2a1d08;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+.extension-panel__empty {
+    margin: 0;
+    color: #5b4b2b;
+    font-size: 12px;
+}
+
+.extension-panel__actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.extension-panel__action {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 6px;
+    border: 0;
+    background-color: #3f2a08;
+    color: #ffd7a3;
+    cursor: pointer;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.extension-panel__action:hover {
+    background-color: #6b4512;
 }
 
 .chrome-install-btn {

--- a/src/renderer/data/main.ts
+++ b/src/renderer/data/main.ts
@@ -1,9 +1,50 @@
-import { DEFAULT_LANGUAGE } from "../shared/constants";
+import { DEFAULT_CHROME_VERSION, DEFAULT_LANGUAGE } from "../shared/constants";
 
 export const defaultHomePage = "https://browserscan.net";
 
 const fallbackUserAgent =
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko)" +
+    ` Chrome/${DEFAULT_CHROME_VERSION} Safari/537.36`;
+
+function compareVersions(current: string, target: string): number {
+    const currentParts = current.split(".").map((part) => Number.parseInt(part, 10) || 0);
+    const targetParts = target.split(".").map((part) => Number.parseInt(part, 10) || 0);
+    const length = Math.max(currentParts.length, targetParts.length);
+
+    for (let index = 0; index < length; index += 1) {
+        const currentValue = currentParts[index] ?? 0;
+        const targetValue = targetParts[index] ?? 0;
+
+        if (currentValue > targetValue) {
+            return 1;
+        }
+
+        if (currentValue < targetValue) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+function normalizeChromeVersion(userAgent: string): string {
+    const match = userAgent.match(/Chrome\/(\d+(?:\.\d+){3})/);
+
+    if (!match) {
+        return userAgent;
+    }
+
+    const [, currentVersion] = match;
+
+    if (compareVersions(currentVersion, DEFAULT_CHROME_VERSION) >= 0) {
+        return userAgent;
+    }
+
+    return userAgent.replace(
+        `Chrome/${currentVersion}`,
+        `Chrome/${DEFAULT_CHROME_VERSION}`,
+    );
+}
 
 function sanitizeUserAgent(raw: string | undefined | null): string | null {
     if (!raw) {
@@ -16,16 +57,19 @@ function sanitizeUserAgent(raw: string | undefined | null): string | null {
         .trim();
 
     if (/Chrome\/[\d.]+/.test(withoutAppSignature)) {
-        return withoutAppSignature.replace(/\s{2,}/g, " ").trim();
+        const normalized = withoutAppSignature.replace(/\s{2,}/g, " ").trim();
+        return normalizeChromeVersion(normalized);
     }
 
     return null;
 }
 
 export const defaultUserAgent =
-    sanitizeUserAgent(
-        typeof navigator !== "undefined" ? navigator.userAgent : undefined,
-    ) || fallbackUserAgent;
+    normalizeChromeVersion(
+        sanitizeUserAgent(
+            typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+        ) || fallbackUserAgent,
+    );
 
 export const defaultBrowserPreference = "chrome";
 

--- a/src/renderer/data/main.ts
+++ b/src/renderer/data/main.ts
@@ -3,9 +3,26 @@ export const defaultHomePage = "https://browserscan.net";
 const fallbackUserAgent =
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
 
+function sanitizeUserAgent(raw: string | undefined | null): string | null {
+    if (!raw) {
+        return null;
+    }
+
+    const withoutAppSignature = raw
+        .replace(/Electron\/[\d.]+\s*/gi, "")
+        .replace(/Multizen\/[\d.]+\s*/gi, "")
+        .trim();
+
+    if (/Chrome\/[\d.]+/.test(withoutAppSignature)) {
+        return withoutAppSignature.replace(/\s{2,}/g, " ").trim();
+    }
+
+    return null;
+}
+
 export const defaultUserAgent =
-    typeof navigator !== "undefined" && navigator.userAgent
-        ? navigator.userAgent
-        : fallbackUserAgent;
+    sanitizeUserAgent(
+        typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+    ) || fallbackUserAgent;
 
 export const defaultBrowserPreference = "chrome";

--- a/src/renderer/data/main.ts
+++ b/src/renderer/data/main.ts
@@ -1,4 +1,11 @@
 export const defaultHomePage = "https://browserscan.net";
-export const defaultUserAgent =
+
+const fallbackUserAgent =
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+export const defaultUserAgent =
+    typeof navigator !== "undefined" && navigator.userAgent
+        ? navigator.userAgent
+        : fallbackUserAgent;
+
 export const defaultBrowserPreference = "chrome";

--- a/src/renderer/data/main.ts
+++ b/src/renderer/data/main.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_LANGUAGE } from "../shared/constants";
+
 export const defaultHomePage = "https://browserscan.net";
 
 const fallbackUserAgent =
@@ -26,3 +28,5 @@ export const defaultUserAgent =
     ) || fallbackUserAgent;
 
 export const defaultBrowserPreference = "chrome";
+
+export const defaultLanguage = DEFAULT_LANGUAGE;

--- a/src/renderer/interface/IStore.ts
+++ b/src/renderer/interface/IStore.ts
@@ -15,6 +15,7 @@ export interface ISession {
         homePage: string;
         userAgent: string;
         browser: BrowserPreference;
+        language: string;
     };
     id: string;
     currentTabIndex: number;

--- a/src/renderer/interface/IStore.ts
+++ b/src/renderer/interface/IStore.ts
@@ -3,7 +3,7 @@ export type BrowserPreference = "chrome";
 export interface ITab {
     id: string;
     type?: "settings";
-    favicon?: null;
+    favicon?: string | null;
     title: string;
     url?: string;
     session: string;

--- a/src/renderer/ipc/browser.ts
+++ b/src/renderer/ipc/browser.ts
@@ -1,0 +1,26 @@
+function getIpcRenderer() {
+    return window.electron?.ipcRenderer;
+}
+
+export async function configureSessionLanguage(
+    sessionId: string | null,
+    language: string | null,
+): Promise<boolean> {
+    const ipcRenderer = getIpcRenderer();
+
+    if (!ipcRenderer) {
+        return false;
+    }
+
+    try {
+        await ipcRenderer.invoke("browser:configure-session", {
+            sessionId,
+            language,
+        });
+
+        return true;
+    } catch (error) {
+        console.error("Failed to configure session language", error);
+        return false;
+    }
+}

--- a/src/renderer/store/modules/sessions.ts
+++ b/src/renderer/store/modules/sessions.ts
@@ -3,6 +3,7 @@ import getters from "@renderer/store/getters";
 import {
     defaultBrowserPreference,
     defaultHomePage,
+    defaultLanguage,
     defaultUserAgent,
 } from "@renderer/data/main";
 import { v4 as uuid } from "uuid";
@@ -28,6 +29,7 @@ export default {
                     homePage: defaultHomePage,
                     userAgent: defaultUserAgent,
                     browser: defaultBrowserPreference,
+                    language: defaultLanguage,
                 },
                 id: sessionId,
                 currentTabIndex: 0,

--- a/src/renderer/store/mutations.ts
+++ b/src/renderer/store/mutations.ts
@@ -5,6 +5,7 @@ import { v4 as uuid } from "uuid";
 import {
     defaultBrowserPreference,
     defaultHomePage,
+    defaultLanguage,
     defaultUserAgent,
 } from "@renderer/data/main";
 
@@ -35,6 +36,7 @@ const mutations: MutationTree<IState> = {
                 homePage: defaultHomePage,
                 userAgent: defaultUserAgent,
                 browser: defaultBrowserPreference,
+                language: defaultLanguage,
             },
         });
         s.currentSessionIndex = s.sessions.length - 1;

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,5 +1,7 @@
 export const DEFAULT_LANGUAGE = "en-US";
 
+export const DEFAULT_CHROME_VERSION = "128.0.6613.138";
+
 export const CHROME_EXTENSION_ID = "gcmhkhdnhjnaeeecmckiodimigmcocla";
 
 export const CHROME_EXTENSION_UPDATE_URL =

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,0 +1,6 @@
+export const DEFAULT_LANGUAGE = "en-US";
+
+export const CHROME_EXTENSION_ID = "gcmhkhdnhjnaeeecmckiodimigmcocla";
+
+export const CHROME_EXTENSION_UPDATE_URL =
+    "https://clients2.google.com/service/update2/crx";

--- a/src/shared/extensions.ts
+++ b/src/shared/extensions.ts
@@ -1,0 +1,17 @@
+import { CHROME_EXTENSION_ID } from "./constants";
+
+export type InstalledExtension = {
+    id: string;
+    name: string;
+    description: string;
+    badge?: string | null;
+};
+
+export const INSTALLED_EXTENSIONS: InstalledExtension[] = [
+    {
+        id: CHROME_EXTENSION_ID,
+        name: "ReachOwl Copy Cookies",
+        description: "Copy cookies from the active tab to your clipboard.",
+        badge: "RC",
+    },
+];

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -12,6 +12,9 @@
         "paths": {
             "@renderer/*": [
                 "src/renderer/*"
+            ],
+            "@shared/*": [
+                "src/shared/*"
             ]
         }
     }


### PR DESCRIPTION
## Summary
- inline a simple monochrome tray icon for macOS instead of shipping a binary asset
- detect the runtime user agent for sessions and surface it in the settings screen
- ensure session settings continue to enforce the detected user agent value

## Testing
- npm run typecheck:node

------
https://chatgpt.com/codex/tasks/task_e_68da16ebabb483218521ef77d62e966d