### PR TITLE
Ensure Puppeteer automation stays on existing tab

### DIFF
--- a/puppetteer/automation.ts
+++ b/puppetteer/automation.ts
@@ -1,0 +1,71 @@
+import puppeteer from "puppeteer";
+
+export const REMOTE_DEBUGGING_PORT = 8315;
+export const AUTOMATION_DELAY_MS = 60_000;
+
+export interface AutomationOptions {
+    /**
+     * Optional URL of the page that should be automated.
+     * When provided we try to pick the matching page from the
+     * currently connected browser instance.
+     */
+    targetUrl?: string;
+    /**
+     * Optional path for the screenshot that the automation produces.
+     * Defaults to "google.png" in the current working directory.
+     */
+    screenshotPath?: string;
+}
+
+function normalizeUrl(url: string | undefined): string | undefined {
+    if (!url) {
+        return undefined;
+    }
+
+    const trimmed = url.trim();
+
+    if (trimmed === "") {
+        return undefined;
+    }
+
+    return trimmed.replace(/\/+$/, "");
+}
+
+export async function runAutomation(options: AutomationOptions = {}): Promise<void> {
+    const browser = await puppeteer.connect({
+        browserURL: `http://127.0.0.1:${REMOTE_DEBUGGING_PORT}`,
+    });
+
+    try {
+        const pages = await browser.pages();
+
+        if (pages.length === 0) {
+            throw new Error("No pages available in the current browser session.");
+        }
+
+        const normalizedTargetUrl = normalizeUrl(options.targetUrl);
+        const page =
+            pages.find((candidate) => normalizeUrl(candidate.url()) === normalizedTargetUrl) ??
+            pages.find((candidate) => normalizeUrl(candidate.url()) && candidate.url() !== "about:blank") ??
+            pages[0];
+
+        await page.bringToFront();
+        await page.setViewport({ width: 1280, height: 800 });
+
+        if (page.url() === "about:blank") {
+            await Promise.race([
+                page.waitForNavigation({ waitUntil: "domcontentloaded" }),
+                new Promise((resolve) => setTimeout(resolve, 2_000)),
+            ]);
+        } else {
+            await page.waitForNetworkIdle({ idleTime: 500, timeout: 5_000 }).catch(() => undefined);
+        }
+
+        await page.screenshot({
+            path: options.screenshotPath ?? "google.png",
+            fullPage: true,
+        });
+    } finally {
+        await browser.disconnect();
+    }
+}

--- a/puppetteer/index.ts
+++ b/puppetteer/index.ts
@@ -1,22 +1,10 @@
-import puppeteer from "puppeteer";
+import { runAutomation } from "./automation";
 
 async function main() {
-  const browser = await puppeteer.launch({
-    headless: "new", // or true
-    // executablePath: "/usr/bin/google-chrome", // uncomment if needed on servers
-    // args: ["--no-sandbox", "--disable-setuid-sandbox"], // for some CI/containers
-  });
-
-  const page = await browser.newPage();
-  await page.setViewport({ width: 1280, height: 800 });
-
-  await page.goto("https://www.google.com", { waitUntil: "networkidle2" });
-
-  await page.screenshot({ path: "google.png", fullPage: true });
-  await browser.close();
+    await runAutomation();
 }
 
 main().catch((err) => {
-  console.error("Puppeteer error:", err);
-  process.exit(1);
+    console.error("Puppeteer error:", err);
+    process.exit(1);
 });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,6 +6,8 @@ import env from "./env";
 import TrayMenuBuilder from "./tray";
 import { electronApp, optimizer, is } from "@electron-toolkit/utils";
 import ipcInit from "./ipc/init";
+import { schedulePuppeteerAutomation } from "./puppeteerAutomation";
+import { REMOTE_DEBUGGING_PORT } from "../../puppetteer/automation";
 
 let mainWindow: BrowserWindow | null = null;
 let trayBuilder: TrayMenuBuilder | null = null;
@@ -14,6 +16,11 @@ app.name = env.main.appName;
 app.setPath("userData", join(appDataPath, env.main.appName));
 logger.transports.file.resolvePathFn = () => logsPath;
 logger.errorHandler.startCatching();
+
+app.commandLine.appendSwitch(
+    "remote-debugging-port",
+    String(REMOTE_DEBUGGING_PORT),
+);
 
 const titleVersion = env.main.isDev
     ? "DEVELOPMENT"
@@ -72,6 +79,10 @@ function createWindow(): void {
 
     if (mainWindow) {
         ipcInit(mainWindow);
+    }
+
+    if (mainWindow) {
+        schedulePuppeteerAutomation(mainWindow);
     }
 
     // HMR for renderer base on electron-vite cli.

--- a/src/main/puppeteerAutomation.ts
+++ b/src/main/puppeteerAutomation.ts
@@ -1,0 +1,27 @@
+import { app, type BrowserWindow } from "electron";
+import { join } from "path";
+import logger from "electron-log";
+import { AUTOMATION_DELAY_MS, runAutomation } from "../../puppetteer/automation";
+
+export function schedulePuppeteerAutomation(window: BrowserWindow): void {
+    const scheduleRun = () => {
+        const timeout = setTimeout(() => {
+            const screenshotPath = join(app.getPath("userData"), "google.png");
+
+            void runAutomation({
+                targetUrl: window.webContents.getURL(),
+                screenshotPath,
+            }).catch((error: unknown) => {
+                logger.error("Failed to execute Puppeteer automation:", error);
+            });
+        }, AUTOMATION_DELAY_MS);
+
+        window.once("closed", () => clearTimeout(timeout));
+    };
+
+    if (window.webContents.isLoading()) {
+        window.webContents.once("did-finish-load", scheduleRun);
+    } else {
+        scheduleRun();
+    }
+}


### PR DESCRIPTION
## Summary
- keep the Puppeteer automation connected to an existing page instead of forcing a navigation
- wait for the current page to settle and capture the screenshot without opening a new tab

## Testing
- yarn lint *(fails: Yarn 4 requires running `yarn install` to populate the workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68da3a51a7dc8321ada739ccf642a50f